### PR TITLE
Only use elem of pointer dep when its not registered

### DIFF
--- a/pkg/router/introspector_factory_default.go
+++ b/pkg/router/introspector_factory_default.go
@@ -26,14 +26,14 @@ func newNextFuncFactory(ctx Context, next HandlerFunc) reflect.Value {
 // newDefaultHandlerArgFactory will create a fake factory that attempts to dependency inject the argument.
 func newDefaultHandlerArgFactory(forType reflect.Type) (HandlerIntrospectorArgFactory, error) {
 	isPointer := false
-	if forType.Kind() == reflect.Pointer {
-		forType = forType.Elem()
+	if _, resolveErr := injector.InjectT(forType); resolveErr != nil && forType.Kind() == reflect.Pointer {
 		isPointer = true
+		forType = forType.Elem()
 	}
 
 	ctx := reflect.New(forType).Interface()
 
-	if forType.Kind() == reflect.Struct {
+	if forType.Kind() == reflect.Struct || forType.Kind() == reflect.Pointer {
 		// First test if its a struct dependency
 		if err := injector.InjectInto(ctx); err != nil {
 			// If not, structs are usually Context objects that hold one or multiple fields


### PR DESCRIPTION
This PR fixes bad dependency injection behaviour when a dependency was registered as a pointer and wouldn't be resolved in handlers. 

![image](https://user-images.githubusercontent.com/43315617/178152035-4699ded0-39b0-4d1f-b4b9-fbc1dbe9acce.png)

This was due to a convenience feature that would resolve a pointer to a non-pointer dependency. This feature did not probe the injector for an existing pointer dependency before attempting a non-pointer dependency, which caused issue #3 