### PR TITLE
Store the ViewBag in Metadata to prevent state loss

### DIFF
--- a/context_renderer.go
+++ b/context_renderer.go
@@ -6,15 +6,14 @@ import (
 
 	"github.com/go-mojito/mojito/pkg/renderer"
 	"github.com/go-mojito/mojito/pkg/router"
-	"github.com/infinytum/structures"
 	"github.com/mitchellh/hashstructure/v2"
 )
 
-var viewCachePrefix = "view_cache_"
+const viewCachePrefix = "view_cache_"
+const viewBagMetadataKey = "mojito.pkg.renderer.ViewBag"
 
 type builtinRenderContext struct {
 	router.Context
-	viewBag renderer.ViewBag
 }
 
 // MustView implements RendererContext
@@ -55,12 +54,15 @@ func (ctx *builtinRenderContext) View(view string) error {
 
 // ViewBag implements RendererContext
 func (ctx *builtinRenderContext) ViewBag() renderer.ViewBag {
-	return ctx.viewBag
+	viewBag, ok := ctx.Context.Metadata().GetOrSet(viewBagMetadataKey, renderer.NewViewBag()).(renderer.ViewBag)
+	if !ok {
+		panic("ViewBag is not a renderer.ViewBag")
+	}
+	return viewBag
 }
 
 func NewRenderContext(ctx router.Context) RendererContext {
 	return &builtinRenderContext{
 		Context: ctx,
-		viewBag: structures.NewMap[string, interface{}](),
 	}
 }


### PR DESCRIPTION
Because of the way extended Context structs are handled, state is lost when they are used in middleware. This issue does not affect a final handler, as the data added to its state is used when the .View or .MustView function is called.

However, whenever a Middleware would modify the state of the RendererContext object, the state would be lost due to the fact that the original context has no idea about the changes made to the extended struct. 

This is fixed by storing any state that must be persistent in the Metadata of a request, which can be read and modified throughout the whole request chain.