### PR TITLE
Add helper methods for reading JSON and XML bodies into an object

### DIFF
--- a/pkg/router/context.go
+++ b/pkg/router/context.go
@@ -22,6 +22,12 @@ type Context interface {
 	// Metadata contains the metadata about the current context
 	Metadata() structures.Map[string, interface{}]
 
+	// ReadJSON reads the request body as JSON and unmarshals it into the given object
+	ReadJSON(obj interface{}) error
+
+	// ReadXML reads the request body as XML and unmarshals it into the given object
+	ReadXML(obj interface{}) error
+
 	// String will write a string to the response body
 	String(body string) error
 

--- a/pkg/router/context_builtin.go
+++ b/pkg/router/context_builtin.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"net/http"
 
 	"github.com/infinytum/structures"
@@ -54,6 +55,16 @@ func (ctx *builtinContext) PrettyJSON(body interface{}) error {
 // Metadata implements Context
 func (ctx *builtinContext) Metadata() structures.Map[string, interface{}] {
 	return ctx.metadata
+}
+
+// ReadJSON reads the request body as JSON and unmarshals it into the given object
+func (ctx *builtinContext) ReadJSON(obj interface{}) error {
+	return json.NewDecoder(ctx.request.GetRequest().Body).Decode(obj)
+}
+
+// ReadXML reads the request body as XML and unmarshals it into the given object
+func (ctx *builtinContext) ReadXML(obj interface{}) error {
+	return xml.NewDecoder(ctx.request.GetRequest().Body).Decode(obj)
 }
 
 // String will write a string to the response body


### PR DESCRIPTION
We have handy helpers for writing JSON, but we are missing read helpers.

How 2 use:

```go
...
    var obj Type
    err := ctx.ReadJSON(&obj)
...
```