### PR TITLE
Use .GetWriter on Response when passing to stdlib implementation

### DIFF
--- a/pkg/router/handler_builtin.go
+++ b/pkg/router/handler_builtin.go
@@ -50,7 +50,7 @@ func (h *builtinHandler) AddMiddleware(middleware interface{}) error {
 			return returnVal[0].Interface().(error)
 		}
 		if middleHandler.Introspection().IsStdlibMiddleware() {
-			(returnVal[0].Interface().(http.Handler)).ServeHTTP(ctx.Response(), ctx.Request().GetRequest())
+			(returnVal[0].Interface().(http.Handler)).ServeHTTP(ctx.Response().GetWriter(), ctx.Request().GetRequest())
 		}
 		return nil
 	}

--- a/pkg/router/introspector_factory_stdlib.go
+++ b/pkg/router/introspector_factory_stdlib.go
@@ -13,7 +13,7 @@ func stdlibRequestFactory(ctx Context, next HandlerFunc) reflect.Value {
 }
 
 func stdlibResponseFactory(ctx Context, next HandlerFunc) reflect.Value {
-	return reflect.ValueOf(ctx.Response())
+	return reflect.ValueOf(ctx.Response().GetWriter())
 }
 
 func stdlibHandlerFactory(ctx Context, next HandlerFunc) reflect.Value {


### PR DESCRIPTION
If the middleware makes their own wrapper around the response writer, mojito can end up in a loop because the passed response writer points to the mojito response object holding the writer instead of the underlying writer.