### PR TITLE
Simplify Compression Code

### DIFF
--- a/middleware/compression.go
+++ b/middleware/compression.go
@@ -8,16 +8,25 @@ import (
 
 // Compression compresses the http response if supported by the client.
 func Compression(ctx mojito.Context, next func() error) (err error) {
-	if strings.Contains(ctx.Request().GetRequest().Header.Get("Connection"), "Upgrade") ||
-		strings.Contains(ctx.Request().GetRequest().Header.Get("Accept"), "text/event-stream") {
+	if strings.Contains(ctx.Request().GetRequest().Header.Get("Connection"), "Upgrade") {
 		return next()
 	}
 
+	// Brotli compression is favored over gzip compression.
 	if strings.Contains(ctx.Request().GetRequest().Header.Get("Accept-Encoding"), "br") {
 		return compressBrotli(ctx, next)
-	} else if strings.Contains(ctx.Request().GetRequest().Header.Get("Accept-Encoding"), "gzip") {
+	}
+
+	// Gzip compression is favored over deflate compression.
+	if strings.Contains(ctx.Request().GetRequest().Header.Get("Accept-Encoding"), "gzip") {
 		return compressGzip(ctx, next)
 	}
+
+	// Deflate compression is favored over identity compression.
+	// TODO: Deflate compression
+
+	// Identity compression is the default.
+	// TODO: Identity compression
 
 	return next()
 }

--- a/middleware/compression.go
+++ b/middleware/compression.go
@@ -8,7 +8,8 @@ import (
 
 // Compression compresses the http response if supported by the client.
 func Compression(ctx mojito.Context, next func() error) (err error) {
-	if strings.Contains(ctx.Request().GetRequest().Header.Get("Connection"), "Upgrade") {
+	if strings.Contains(ctx.Request().GetRequest().Header.Get("Connection"), "Upgrade") ||
+		strings.Contains(ctx.Request().GetRequest().Header.Get("Accept"), "text/event-stream") {
 		return next()
 	}
 


### PR DESCRIPTION
Simplify the code for compression to make it easier to understand, also remove redundant calls for Content-Length