### PR TITLE
Implement string reading, better receive error handling

### DIFF
--- a/websocket/context.go
+++ b/websocket/context.go
@@ -29,6 +29,7 @@ var upgrader = websocket.Upgrader{
 // Context defines a context for websocket functionality.
 type Context interface {
 	router.Context
+	Closed() bool
 	EnableReadCheck()
 	Receive(out interface{}) error
 	Send(data interface{}) error

--- a/websocket/context_websocket.go
+++ b/websocket/context_websocket.go
@@ -110,7 +110,7 @@ func (ctx *builtinContext) Send(data interface{}) (err error) {
 		err = errors.New("unsupported data type")
 	}
 
-	// Close connection since read underneath failed
+	// Close connection since send underneath failed
 	if err != nil {
 		ctx.close()
 	}


### PR DESCRIPTION
Multiple Issues fixed:

- Reading strings was not implemented
- Many websocket specific errors did not cause the connection to be considered closed.
- Closed() was not exposed
